### PR TITLE
WIP Shared client

### DIFF
--- a/clients/erigon/Dockerfile
+++ b/clients/erigon/Dockerfile
@@ -8,6 +8,12 @@ FROM $baseimage:$tag
 USER root
 
 RUN apk add --no-cache bash curl jq
+RUN apt-get update && apt-get install -y \
+    build-essential \
+    ca-certificates \
+    curl \
+    git \
+    jq && rm -rf /var/lib/apt/lists/*
 
 # Create version.txt
 RUN erigon --version | sed -e 's/erigon version \(.*\)/\1/' > /version.txt

--- a/clients/erigon/Dockerfile
+++ b/clients/erigon/Dockerfile
@@ -7,7 +7,6 @@ FROM $baseimage:$tag
 # to install additional commands, so switch back to root.
 USER root
 
-RUN apk add --no-cache bash curl jq
 RUN apt-get update && apt-get install -y \
     build-essential \
     ca-certificates \

--- a/clients/nethermind/Dockerfile.git
+++ b/clients/nethermind/Dockerfile.git
@@ -12,7 +12,7 @@ RUN echo "Cloning: $github - $tag" && \
     dotnet build -c release
 
 ## Final stage: Sets up the environment for running nethermind
-FROM mcr.microsoft.com/dotnet/aspnet:9.0
+FROM mcr.microsoft.com/dotnet/aspnet:9.0-noble
 
 # Copy compiled binary from builder
 COPY --from=build /nethermind/src/Nethermind/artifacts/bin/Nethermind.Runner/release /nethermind

--- a/clients/nethermind/Dockerfile.local
+++ b/clients/nethermind/Dockerfile.local
@@ -11,7 +11,7 @@ ADD $local_path /nethermind
 RUN cd /nethermind/src/Nethermind/Nethermind.Runner && dotnet build -c release
 
 ## Final stage: Sets up the environment for running nethermind
-FROM mcr.microsoft.com/dotnet/aspnet:9.0
+FROM mcr.microsoft.com/dotnet/aspnet:9.0-noble
 
 # Copy compiled binary from builder
 COPY --from=build /nethermind/src/Nethermind/artifacts/bin/Nethermind.Runner/release /nethermind

--- a/clients/reth/Dockerfile
+++ b/clients/reth/Dockerfile
@@ -20,7 +20,7 @@ ADD enode.sh /hive-bin/enode.sh
 RUN chmod +x /hive-bin/enode.sh
 
 # Create version.txt
-RUN /usr/local/bin/reth --version | sed -e 's/reth \(.*\)/\1/' > /version.txt
+RUN /usr/local/bin/reth --version | head -2 | awk 'NR==1 {gsub("reth Version: ", ""); version=$0} NR==2 {gsub("Commit SHA: ", ""); sha=substr($0, 1, 8)} END {print version"+"sha}' > /version.txt
 
 # Export the usual networking ports to allow outside access to the node.
 EXPOSE 8545 8546 30303 30303/udp

--- a/clients/reth/Dockerfile.git
+++ b/clients/reth/Dockerfile.git
@@ -32,7 +32,7 @@ COPY enode.sh /hive-bin/enode.sh
 RUN chmod +x /reth.sh /hive-bin/enode.sh
 
 # Create version.txt
-RUN /usr/local/bin/reth --version | head -1 > /version.txt
+RUN /usr/local/bin/reth --version | head -2 | awk 'NR==1 {gsub("reth Version: ", ""); version=$0} NR==2 {gsub("Commit SHA: ", ""); sha=substr($0, 1, 8)} END {print version"+"sha}' > /version.txt
 
 # Export the usual networking ports
 EXPOSE 8545 8546 30303 30303/udp

--- a/clients/reth/Dockerfile.local
+++ b/clients/reth/Dockerfile.local
@@ -30,7 +30,7 @@ COPY enode.sh /hive-bin/enode.sh
 RUN chmod +x /reth.sh /hive-bin/enode.sh
 
 # Create version.txt
-RUN /usr/local/bin/reth --version | head -1 > /version.txt
+RUN /usr/local/bin/reth --version | head -2 | awk 'NR==1 {gsub("reth Version: ", ""); version=$0} NR==2 {gsub("Commit SHA: ", ""); sha=substr($0, 1, 8)} END {print version"+"sha}' > /version.txt
 
 # Export the usual networking ports
 EXPOSE 8545 8546 30303 30303/udp

--- a/cmd/hiveview/assets/lib/app-suite.js
+++ b/cmd/hiveview/assets/lib/app-suite.js
@@ -327,9 +327,9 @@ function testHasClients(testData, suiteData) {
         return true;
     }
     
-    if (suiteData && suiteData.sharedClients) {
-        for (let clientID in suiteData.sharedClients) {
-            let clientName = suiteData.sharedClients[clientID].name;
+    if (suiteData && suiteData.clientInfo) {
+        for (let clientID in suiteData.clientInfo) {
+            let clientName = suiteData.clientInfo[clientID].name;
             if (testData.name.includes(clientName)) {
                 return true;
             }
@@ -401,14 +401,14 @@ function formatClientLogsList(suiteData, testIndex, clientInfo) {
     
     // For backward compatibility - if test name includes client name, add that client
     // This handles the case where tests don't yet have clientInfo or clientLogs properly populated
-    if (suiteData.sharedClients) {
+    if (suiteData.clientInfo) {
         
         // First try to match by existing client logs
         if (usedSharedClients.size === 0) {
             // Group clients by name to identify if there are multiple of the same type
             let clientsByName = {};
-            for (let instanceID in suiteData.sharedClients) {
-                let sharedClient = suiteData.sharedClients[instanceID];
+            for (let instanceID in suiteData.clientInfo) {
+                let sharedClient = suiteData.clientInfo[instanceID];
                 if (!sharedClient.logFile) continue; // Skip if no log file
                 
                 // Add to the clients by name map
@@ -429,7 +429,7 @@ function formatClientLogsList(suiteData, testIndex, clientInfo) {
         }
         
         // Now add all the used shared clients that haven't been handled yet
-        for (let instanceID in suiteData.sharedClients) {
+        for (let instanceID in suiteData.clientInfo) {
             // First check if this client is explicitly registered in the test's clientLogs
             // This is the most reliable way to determine if a client was used in a test
             const explicitlyRegistered = testCase && 
@@ -451,7 +451,7 @@ function formatClientLogsList(suiteData, testIndex, clientInfo) {
                 continue;
             }
             
-            let sharedClient = suiteData.sharedClients[instanceID];
+            let sharedClient = suiteData.clientInfo[instanceID];
             
             // Skip if no log file
             if (!sharedClient.logFile) {

--- a/cmd/hiveview/assets/lib/app-suite.js
+++ b/cmd/hiveview/assets/lib/app-suite.js
@@ -317,21 +317,175 @@ function deselectTest(row, closeDetails) {
     history.replaceState(null, null, '#');
 }
 
-function testHasClients(testData) {
-    return testData.clientInfo && Object.getOwnPropertyNames(testData.clientInfo).length > 0;
+function testHasClients(testData, suiteData) {
+    if (testData.clientInfo && Object.getOwnPropertyNames(testData.clientInfo).length > 0) {
+        return true;
+    }
+    
+    if (testData.summaryResult && testData.summaryResult.clientLogs && 
+        Object.keys(testData.summaryResult.clientLogs).length > 0) {
+        return true;
+    }
+    
+    if (suiteData && suiteData.sharedClients) {
+        for (let clientID in suiteData.sharedClients) {
+            let clientName = suiteData.sharedClients[clientID].name;
+            if (testData.name.includes(clientName)) {
+                return true;
+            }
+        }
+    }
+    
+    return false;
 }
 
 // formatClientLogsList turns the clientInfo part of a test into a list of links.
 function formatClientLogsList(suiteData, testIndex, clientInfo) {
     let links = [];
-    for (let instanceID in clientInfo) {
-        let instanceInfo = clientInfo[instanceID];
-        let logfile = routes.resultsRoot + instanceInfo.logFile;
-        let url = routes.clientLog(suiteData.suiteID, suiteData.name, testIndex, logfile);
-        let link = html.makeLink(url, instanceInfo.name);
-        link.classList.add('log-link');
-        links.push(link.outerHTML);
+    let testCase = suiteData.testCases[testIndex];
+    let usedSharedClients = new Set(); // Track which shared clients were used in this test
+    
+    // First, check if the test has specific information about which shared clients it used
+    if (testCase && testCase.summaryResult && testCase.summaryResult.clientLogs) {
+        for (let clientID in testCase.summaryResult.clientLogs) {
+            usedSharedClients.add(clientID);
+        }
     }
+    
+    // Handle clients listed directly in the test's clientInfo
+    if (clientInfo) {
+        for (let instanceID in clientInfo) {
+            let instanceInfo = clientInfo[instanceID];
+            
+            // Skip if no log file
+            if (!instanceInfo.logFile) {
+                continue;
+            }
+            
+            // If it's a shared client, mark it as used
+            if (instanceInfo.isShared) {
+                usedSharedClients.add(instanceID);
+            }
+            
+            let logfile = routes.resultsRoot + instanceInfo.logFile;
+            let url = routes.clientLog(suiteData.suiteID, suiteData.name, testIndex, logfile);
+            
+            // Check if this is a shared client with a log segment
+            let hasSegment = testCase && 
+                             testCase.summaryResult && 
+                             testCase.summaryResult.clientLogs && 
+                             testCase.summaryResult.clientLogs[instanceID];
+            
+            if (hasSegment) {
+                // If we have a log segment, update the URL to include the line numbers
+                const clientLogInfo = testCase.summaryResult.clientLogs[instanceID];
+                
+                // Use line numbers from the backend
+                url += `#L${clientLogInfo.startLine}-${clientLogInfo.endLine}`;
+            }
+            
+            // Add "(shared)" indicator for shared clients
+            let clientName = instanceInfo.name;
+            if (instanceInfo.isShared || hasSegment) {
+                clientName += " (shared)";
+            }
+            
+            let link = html.makeLink(url, clientName);
+            link.classList.add('log-link');
+            if (instanceInfo.isShared) {
+                link.classList.add('shared-client-log');
+            }
+            links.push(link.outerHTML);
+        }
+    }
+    
+    // For backward compatibility - if test name includes client name, add that client
+    // This handles the case where tests don't yet have clientInfo or clientLogs properly populated
+    if (suiteData.sharedClients) {
+        
+        // First try to match by existing client logs
+        if (usedSharedClients.size === 0) {
+            // Group clients by name to identify if there are multiple of the same type
+            let clientsByName = {};
+            for (let instanceID in suiteData.sharedClients) {
+                let sharedClient = suiteData.sharedClients[instanceID];
+                if (!sharedClient.logFile) continue; // Skip if no log file
+                
+                // Add to the clients by name map
+                if (!clientsByName[sharedClient.name]) {
+                    clientsByName[sharedClient.name] = [];
+                }
+                clientsByName[sharedClient.name].push({id: instanceID, client: sharedClient});
+            }
+            
+            // Now check test name for client match, but only if there's exactly one client of that type
+            for (let clientName in clientsByName) {
+                if (testCase.name.includes(clientName) && clientsByName[clientName].length === 1) {
+                    // If there's exactly one client of this type, it's safe to auto-register
+                    let instanceID = clientsByName[clientName][0].id;
+                    usedSharedClients.add(instanceID);
+                }
+            }
+        }
+        
+        // Now add all the used shared clients that haven't been handled yet
+        for (let instanceID in suiteData.sharedClients) {
+            // First check if this client is explicitly registered in the test's clientLogs
+            // This is the most reliable way to determine if a client was used in a test
+            const explicitlyRegistered = testCase && 
+                                       testCase.summaryResult && 
+                                       testCase.summaryResult.clientLogs && 
+                                       testCase.summaryResult.clientLogs[instanceID];
+            
+            if (explicitlyRegistered) {
+                usedSharedClients.add(instanceID);
+            }
+            
+            // Skip if not used by this test (based on explicit tracking or name matching)
+            if (!usedSharedClients.has(instanceID)) {
+                continue;
+            }
+            
+            // Skip clients already handled in clientInfo
+            if (clientInfo && instanceID in clientInfo) {
+                continue;
+            }
+            
+            let sharedClient = suiteData.sharedClients[instanceID];
+            
+            // Skip if no log file
+            if (!sharedClient.logFile) {
+                continue;
+            }
+            
+            // Create a link to the full log file for this shared client
+            let logfile = routes.resultsRoot + sharedClient.logFile;
+            let url = routes.clientLog(suiteData.suiteID, suiteData.name, testIndex, logfile);
+            
+            // Check if we have specific log segments for this client in this test
+            let hasSegment = testCase && 
+                             testCase.summaryResult && 
+                             testCase.summaryResult.clientLogs && 
+                             testCase.summaryResult.clientLogs[instanceID];
+            
+            if (hasSegment) {
+                // If we have a log segment, update the URL to include the line numbers
+                const clientLogInfo = testCase.summaryResult.clientLogs[instanceID];
+                
+                // Only add line range if we have valid line numbers (both > 0)
+                if (clientLogInfo.startLine > 0 && clientLogInfo.endLine > 0) {
+                    url += `#L${clientLogInfo.startLine}-${clientLogInfo.endLine}`;
+                }
+            }
+            
+            let clientName = sharedClient.name + " (shared)";
+            let link = html.makeLink(url, clientName);
+            
+            link.classList.add('log-link', 'shared-client-log');
+            links.push(link.outerHTML);
+        }
+    }
+    
     return links.join(', ');
 }
 
@@ -360,7 +514,7 @@ function formatTestDetails(suiteData, row) {
         p.innerHTML = formatTestStatus(d.summaryResult);
         container.appendChild(p);
     }
-    if (!row.column('logs:name').responsiveHidden() && testHasClients(d)) {
+    if (!row.column('logs:name').responsiveHidden() && testHasClients(d, suiteData)) {
         let p = document.createElement('p');
         p.innerHTML = '<b>Clients:</b> ' + formatClientLogsList(suiteData, d.testIndex, d.clientInfo);
         container.appendChild(p);

--- a/hivesim/data.go
+++ b/hivesim/data.go
@@ -23,18 +23,6 @@ type TestStartInfo struct {
 	Description string `json:"description"`
 }
 
-// LogOffset tracks the start and end positions in a log file.
-type LogOffset struct {
-	Start int64 `json:"start"` // Byte offset where this section begins
-	End   int64 `json:"end"`   // Byte offset where this section ends
-}
-
-// ClientLogInfo tracks log offsets for a specific client in a test.
-type ClientLogInfo struct {
-	ClientID  string    `json:"client_id"` // ID of the client container
-	LogOffset LogOffset `json:"log_offset"` // Offset range in the log file
-}
-
 // ExecInfo is the result of running a command in a client container.
 type ExecInfo struct {
 	Stdout   string `json:"stdout"`
@@ -57,25 +45,4 @@ type ClientDefinition struct {
 // HasRole reports whether the client has the given role.
 func (m *ClientDefinition) HasRole(role string) bool {
 	return slices.Contains(m.Meta.Roles, role)
-}
-
-// ClientMode defines whether a client is shared across tests or dedicated to a single test.
-// Two modes are supported: DedicatedClient (default) and SharedClient.
-type ClientMode int
-
-const (
-	// DedicatedClient is a client that is used for a single test (default behavior)
-	DedicatedClient ClientMode = iota
-	// SharedClient is a client that is shared across multiple tests in a suite
-	SharedClient
-)
-
-// SharedClientInfo contains information about a shared client instance.
-// This includes container identification and connectivity information.
-type SharedClientInfo struct {
-	ID        string // Container ID
-	Type      string // Client type
-	IP        string // Client IP address
-	CreatedAt int64  // Timestamp when client was created
-	LogFile   string // Path to client log file
 }

--- a/hivesim/data.go
+++ b/hivesim/data.go
@@ -23,6 +23,18 @@ type TestStartInfo struct {
 	Description string `json:"description"`
 }
 
+// LogOffset tracks the start and end positions in a log file.
+type LogOffset struct {
+	Start int64 `json:"start"` // Byte offset where this section begins
+	End   int64 `json:"end"`   // Byte offset where this section ends
+}
+
+// ClientLogInfo tracks log offsets for a specific client in a test.
+type ClientLogInfo struct {
+	ClientID  string    `json:"client_id"` // ID of the client container
+	LogOffset LogOffset `json:"log_offset"` // Offset range in the log file
+}
+
 // ExecInfo is the result of running a command in a client container.
 type ExecInfo struct {
 	Stdout   string `json:"stdout"`
@@ -45,4 +57,25 @@ type ClientDefinition struct {
 // HasRole reports whether the client has the given role.
 func (m *ClientDefinition) HasRole(role string) bool {
 	return slices.Contains(m.Meta.Roles, role)
+}
+
+// ClientMode defines whether a client is shared across tests or dedicated to a single test.
+// Two modes are supported: DedicatedClient (default) and SharedClient.
+type ClientMode int
+
+const (
+	// DedicatedClient is a client that is used for a single test (default behavior)
+	DedicatedClient ClientMode = iota
+	// SharedClient is a client that is shared across multiple tests in a suite
+	SharedClient
+)
+
+// SharedClientInfo contains information about a shared client instance.
+// This includes container identification and connectivity information.
+type SharedClientInfo struct {
+	ID        string // Container ID
+	Type      string // Client type
+	IP        string // Client IP address
+	CreatedAt int64  // Timestamp when client was created
+	LogFile   string // Path to client log file
 }

--- a/hivesim/hive.go
+++ b/hivesim/hive.go
@@ -215,7 +215,7 @@ func (sim *Simulation) StartSharedClient(testSuite SuiteID, clientType string, o
 		return "", nil, errors.New("StartSharedClient is not supported in docs mode")
 	}
 	var (
-		url  = fmt.Sprintf("%s/testsuite/%d/shared-client", sim.url, testSuite)
+		url  = fmt.Sprintf("%s/testsuite/%d/node", sim.url, testSuite)
 		resp simapi.StartNodeResponse
 	)
 
@@ -249,7 +249,7 @@ func (sim *Simulation) GetSharedClientInfo(testSuite SuiteID, clientID string) (
 		return nil, errors.New("GetSharedClientInfo is not supported in docs mode")
 	}
 	var (
-		url  = fmt.Sprintf("%s/testsuite/%d/shared-client/%s", sim.url, testSuite, clientID)
+		url  = fmt.Sprintf("%s/testsuite/%d/node/%s", sim.url, testSuite, clientID)
 		resp SharedClientInfo
 	)
 	err := get(url, &resp)
@@ -263,7 +263,7 @@ func (sim *Simulation) GetClientLogOffset(testSuite SuiteID, clientID string) (i
 		return 0, errors.New("GetClientLogOffset is not supported in docs mode")
 	}
 	var (
-		url  = fmt.Sprintf("%s/testsuite/%d/shared-client/%s/log-offset", sim.url, testSuite, clientID)
+		url  = fmt.Sprintf("%s/testsuite/%d/node/%s/log-offset", sim.url, testSuite, clientID)
 		resp int64
 	)
 	err := get(url, &resp)
@@ -276,7 +276,7 @@ func (sim *Simulation) ExecSharedClient(testSuite SuiteID, clientID string, cmd 
 		return nil, errors.New("ExecSharedClient is not supported in docs mode")
 	}
 	var (
-		url  = fmt.Sprintf("%s/testsuite/%d/shared-client/%s/exec", sim.url, testSuite, clientID)
+		url  = fmt.Sprintf("%s/testsuite/%d/node/%s/exec", sim.url, testSuite, clientID)
 		req  = &simapi.ExecRequest{Command: cmd}
 		resp *ExecInfo
 	)

--- a/hivesim/hive.go
+++ b/hivesim/hive.go
@@ -270,6 +270,20 @@ func (sim *Simulation) GetClientLogOffset(testSuite SuiteID, clientID string) (i
 	return resp, err
 }
 
+// ExecSharedClient runs a command in a shared client container.
+func (sim *Simulation) ExecSharedClient(testSuite SuiteID, clientID string, cmd []string) (*ExecInfo, error) {
+	if sim.docs != nil {
+		return nil, errors.New("ExecSharedClient is not supported in docs mode")
+	}
+	var (
+		url  = fmt.Sprintf("%s/testsuite/%d/shared-client/%s/exec", sim.url, testSuite, clientID)
+		req  = &simapi.ExecRequest{Command: cmd}
+		resp *ExecInfo
+	)
+	err := post(url, req, &resp)
+	return resp, err
+}
+
 // StopClient signals to the host that the node is no longer required.
 func (sim *Simulation) StopClient(testSuite SuiteID, test TestID, nodeid string) error {
 	if sim.docs != nil {

--- a/hivesim/hive.go
+++ b/hivesim/hive.go
@@ -241,20 +241,6 @@ func (sim *Simulation) StartSharedClient(testSuite SuiteID, clientType string, o
 	return resp.ID, ip, nil
 }
 
-// GetSharedClientInfo retrieves information about a shared client,
-// including its ID, type, IP and log file location.
-func (sim *Simulation) GetSharedClientInfo(testSuite SuiteID, clientID string) (*SharedClientInfo, error) {
-	if sim.docs != nil {
-		return nil, errors.New("GetSharedClientInfo is not supported in docs mode")
-	}
-	var (
-		url  = fmt.Sprintf("%s/testsuite/%d/node/%s", sim.url, testSuite, clientID)
-		resp SharedClientInfo
-	)
-	err := get(url, &resp)
-	return &resp, err
-}
-
 // ExecSharedClient runs a command in a shared client container.
 func (sim *Simulation) ExecSharedClient(testSuite SuiteID, clientID string, cmd []string) (*ExecInfo, error) {
 	if sim.docs != nil {

--- a/hivesim/hive.go
+++ b/hivesim/hive.go
@@ -255,20 +255,6 @@ func (sim *Simulation) GetSharedClientInfo(testSuite SuiteID, clientID string) (
 	return &resp, err
 }
 
-// GetClientLogOffset gets the current offset position in a shared client's log file.
-// This is used for tracking log segments in shared clients across multiple tests.
-func (sim *Simulation) GetClientLogOffset(testSuite SuiteID, clientID string) (int64, error) {
-	if sim.docs != nil {
-		return 0, errors.New("GetClientLogOffset is not supported in docs mode")
-	}
-	var (
-		url  = fmt.Sprintf("%s/testsuite/%d/node/%s/log-offset", sim.url, testSuite, clientID)
-		resp int64
-	)
-	err := get(url, &resp)
-	return resp, err
-}
-
 // ExecSharedClient runs a command in a shared client container.
 func (sim *Simulation) ExecSharedClient(testSuite SuiteID, clientID string, cmd []string) (*ExecInfo, error) {
 	if sim.docs != nil {
@@ -283,12 +269,10 @@ func (sim *Simulation) ExecSharedClient(testSuite SuiteID, clientID string, cmd 
 	return resp, err
 }
 
-// RegisterNode registers a client with a test. This is normally handled
-// automatically by StartClient, but can be used directly by a test to
-// register a reference to a shared client.
-func (sim *Simulation) RegisterNode(testSuite SuiteID, test TestID, clientID string) error {
+// RegisterSharedNode registers a shared client with a test.
+func (sim *Simulation) RegisterSharedNode(testSuite SuiteID, test TestID, clientID string) error {
 	if sim.docs != nil {
-		return errors.New("RegisterNode is not supported in docs mode")
+		return errors.New("RegisterSharedNode is not supported in docs mode")
 	}
 
 	req, err := http.NewRequest(http.MethodPost, fmt.Sprintf("%s/testsuite/%d/node/%s/test/%d", sim.url, testSuite, clientID, test), nil)

--- a/hivesim/shared_client_test.go
+++ b/hivesim/shared_client_test.go
@@ -1,0 +1,291 @@
+package hivesim
+
+import (
+	"encoding/json"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/ethereum/hive/internal/fakes"
+	"github.com/ethereum/hive/internal/libhive"
+	"github.com/ethereum/hive/internal/simapi"
+)
+
+// Tests shared client functionality by mocking server responses.
+func TestStartSharedClient(t *testing.T) {
+	// This test creates a test HTTP server that mocks the simulation API.
+	// It responds to just the calls we need for this test, ignoring others.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/testsuite":
+			// StartSuite
+			json.NewEncoder(w).Encode(0) // Return suite ID
+		case "/testsuite/0/shared-client":
+			// StartSharedClient
+			json.NewEncoder(w).Encode(simapi.StartNodeResponse{
+				ID: "container1",
+				IP: "192.0.2.1",
+			})
+		case "/testsuite/0/shared-client/container1":
+			// GetSharedClientInfo
+			json.NewEncoder(w).Encode(simapi.NodeResponse{
+				ID:   "container1",
+				Name: "client-1",
+			})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	sim := NewAt(srv.URL)
+
+	// Start a test suite
+	suiteID, err := sim.StartSuite(&simapi.TestRequest{Name: "shared-client-test-suite"}, "Testing shared clients")
+	if err != nil {
+		t.Fatal("can't start suite:", err)
+	}
+
+	// Start a shared client
+	containerID, ip, err := sim.StartSharedClient(suiteID, "client-1", Params(map[string]string{
+		"HIVE_PARAM": "value",
+	}))
+	if err != nil {
+		t.Fatal("can't start shared client:", err)
+	}
+
+	if containerID != "container1" {
+		t.Errorf("wrong container ID: got %q, want %q", containerID, "container1")
+	}
+	expected := net.ParseIP("192.0.2.1")
+	if !ip.Equal(expected) {
+		t.Errorf("wrong IP returned: got %v, want %v", ip, expected)
+	}
+
+	// Get client info
+	info, err := sim.GetSharedClientInfo(suiteID, containerID)
+	if err != nil {
+		t.Fatal("can't get shared client info:", err)
+	}
+
+	if info.ID != "container1" {
+		t.Errorf("wrong container ID in info: got %q, want %q", info.ID, "container1")
+	}
+}
+
+// Tests AddSharedClient method in Suite.
+func TestAddSharedClient(t *testing.T) {
+	var startedContainers int
+
+	tm, srv := newFakeAPI(&fakes.BackendHooks{
+		StartContainer: func(image, containerID string, opt libhive.ContainerOptions) (*libhive.ContainerInfo, error) {
+			startedContainers++
+			return &libhive.ContainerInfo{
+				ID: containerID,
+				IP: "192.0.2.1",
+			}, nil
+		},
+	})
+	defer srv.Close()
+	defer tm.Terminate()
+
+	suite := Suite{
+		Name:        "shared-client-suite",
+		Description: "Testing shared client registration",
+	}
+	suite.AddSharedClient("shared1", "client-1", Params(map[string]string{
+		"PARAM1": "value1",
+	}))
+	
+	suite.Add(TestSpec{
+		Name: "test-using-shared-client",
+		Run: func(t *T) {
+			client := t.GetSharedClient("shared1")
+			if client == nil {
+				t.Fatal("shared client not found")
+			}
+			
+			if client.Type != "client-1" {
+				t.Errorf("wrong client type: got %q, want %q", client.Type, "client-1")
+			}
+			if !client.IsShared {
+				t.Error("IsShared flag not set on client")
+			}
+		},
+	})
+
+	sim := NewAt(srv.URL)
+	err := RunSuite(sim, suite)
+	if err != nil {
+		t.Fatal("suite run failed:", err)
+	}
+
+	if startedContainers == 0 {
+		t.Error("no containers were started")
+	}
+	
+	tm.Terminate()
+	results := tm.Results()
+	removeTimestamps(results)
+	
+	if len(results) == 0 {
+		t.Fatal("no test results")
+	}
+	
+	suiteResult := results[0]
+	if suiteResult.SharedClients == nil || len(suiteResult.SharedClients) == 0 {
+		t.Error("no shared clients in test results")
+	}
+}
+
+// Tests log offset tracking.
+func TestSharedClientLogOffset(t *testing.T) {
+	// Mock HTTP server for testing the log offset API
+	var offsetValue int64 = 0
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/testsuite":
+			// StartSuite
+			json.NewEncoder(w).Encode(0) // Return suite ID
+		case "/testsuite/0/shared-client":
+			// StartSharedClient
+			json.NewEncoder(w).Encode(simapi.StartNodeResponse{
+				ID: "container1",
+				IP: "192.0.2.1",
+			})
+		case "/testsuite/0/shared-client/container1/log-offset":
+			// GetClientLogOffset - increment the offset each time it's called
+			currentOffset := offsetValue
+			offsetValue += 100 // Simulate log growth
+			json.NewEncoder(w).Encode(currentOffset)
+		case "/testsuite/0/shared-client/container1/exec":
+			// ExecSharedClient
+			json.NewEncoder(w).Encode(&ExecInfo{
+				Stdout:   "test output",
+				ExitCode: 0,
+			})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	sim := NewAt(srv.URL)
+	suiteID, err := sim.StartSuite(&simapi.TestRequest{Name: "log-offset-suite"}, "Testing log offset")
+	if err != nil {
+		t.Fatal("can't start suite:", err)
+	}
+
+	containerID, _, err := sim.StartSharedClient(suiteID, "client-1")
+	if err != nil {
+		t.Fatal("can't start shared client:", err)
+	}
+
+	// Get initial offset
+	initialOffset, err := sim.GetClientLogOffset(suiteID, containerID)
+	if err != nil {
+		t.Fatal("can't get initial log offset:", err)
+	}
+	if initialOffset != 0 {
+		t.Errorf("wrong initial offset: got %d, want 0", initialOffset)
+	}
+
+	// Simulate a command that generates logs
+	_, err = sim.ExecSharedClient(suiteID, containerID, []string{"/bin/echo", "test1"})
+	if err != nil {
+		t.Fatal("exec failed:", err)
+	}
+
+	// Get new offset - should have increased
+	newOffset, err := sim.GetClientLogOffset(suiteID, containerID)
+	if err != nil {
+		t.Fatal("can't get new log offset:", err)
+	}
+	if newOffset <= initialOffset {
+		t.Errorf("offset didn't increase: got %d, want > %d", newOffset, initialOffset)
+	}
+}
+
+// Tests log extraction functionality.
+func TestSharedClientLogExtraction(t *testing.T) {
+	// We can't fully test the log extraction in unit tests because it depends on file I/O.
+	// However, we can verify that the API endpoints are called correctly.
+	// The actual file operations are tested in integration tests.
+
+	// This test ensures that:
+	// 1. We use a MockSuite instead of real test cases
+	// 2. We verify that the ClientLogs structure is correctly set up
+
+	// Create a mock ClientLogs map for our test result
+	clientLogs := make(map[string]*libhive.ClientLogSegment)
+	clientLogs["shared1"] = &libhive.ClientLogSegment{
+		Start:    0,
+		End:      100,
+		ClientID: "container1",
+	}
+
+	// Create a mock test result
+	mockResult := &libhive.TestResult{
+		Pass:       true,
+		ClientLogs: clientLogs,
+	}
+
+	// Verify the test result has client logs
+	if mockResult.ClientLogs == nil {
+		t.Error("no client logs in test results")
+	}
+
+	if len(mockResult.ClientLogs) == 0 {
+		t.Error("empty client logs map")
+	}
+
+	// Verify the log segment values
+	logSegment := mockResult.ClientLogs["shared1"]
+	if logSegment.Start != 0 || logSegment.End != 100 || logSegment.ClientID != "container1" {
+		t.Errorf("unexpected log segment values: got %+v", logSegment)
+	}
+}
+
+// Tests GetClientLogOffset function.
+func TestGetClientLogOffset(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/testsuite":
+			// StartSuite
+			json.NewEncoder(w).Encode(0) // Return suite ID
+		case "/testsuite/0/shared-client":
+			// StartSharedClient
+			json.NewEncoder(w).Encode(simapi.StartNodeResponse{
+				ID: "container1",
+				IP: "192.0.2.1",
+			})
+		case "/testsuite/0/shared-client/container1/log-offset":
+			// GetClientLogOffset
+			json.NewEncoder(w).Encode(int64(0)) // Initial log offset
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	sim := NewAt(srv.URL)
+	suiteID, err := sim.StartSuite(&simapi.TestRequest{Name: "log-offset-test"}, "Test GetClientLogOffset")
+	if err != nil {
+		t.Fatal("can't start suite:", err)
+	}
+
+	containerID, _, err := sim.StartSharedClient(suiteID, "client-1")
+	if err != nil {
+		t.Fatal("can't start shared client:", err)
+	}
+
+	offset, err := sim.GetClientLogOffset(suiteID, containerID)
+	if err != nil {
+		t.Fatal("get log offset failed:", err)
+	}
+
+	if offset != 0 {
+		t.Errorf("wrong initial log offset: got %d, want 0", offset)
+	}
+}

--- a/hivesim/shared_client_test.go
+++ b/hivesim/shared_client_test.go
@@ -97,7 +97,7 @@ func TestAddSharedClient(t *testing.T) {
 	suite.AddSharedClient("shared1", "client-1", Params(map[string]string{
 		"PARAM1": "value1",
 	}))
-	
+
 	suite.Add(TestSpec{
 		Name: "test-using-shared-client",
 		Run: func(t *T) {
@@ -105,7 +105,7 @@ func TestAddSharedClient(t *testing.T) {
 			if client == nil {
 				t.Fatal("shared client not found")
 			}
-			
+
 			if client.Type != "client-1" {
 				t.Errorf("wrong client type: got %q, want %q", client.Type, "client-1")
 			}
@@ -124,17 +124,17 @@ func TestAddSharedClient(t *testing.T) {
 	if startedContainers == 0 {
 		t.Error("no containers were started")
 	}
-	
+
 	tm.Terminate()
 	results := tm.Results()
 	removeTimestamps(results)
-	
+
 	if len(results) == 0 {
 		t.Fatal("no test results")
 	}
-	
+
 	suiteResult := results[0]
-	if suiteResult.SharedClients == nil || len(suiteResult.SharedClients) == 0 {
+	if suiteResult.ClientInfo == nil || len(suiteResult.ClientInfo) == 0 {
 		t.Error("no shared clients in test results")
 	}
 }

--- a/hivesim/shared_client_test.go
+++ b/hivesim/shared_client_test.go
@@ -21,13 +21,13 @@ func TestStartSharedClient(t *testing.T) {
 		case "/testsuite":
 			// StartSuite
 			json.NewEncoder(w).Encode(0) // Return suite ID
-		case "/testsuite/0/shared-client":
+		case "/testsuite/0/node":
 			// StartSharedClient
 			json.NewEncoder(w).Encode(simapi.StartNodeResponse{
 				ID: "container1",
 				IP: "192.0.2.1",
 			})
-		case "/testsuite/0/shared-client/container1":
+		case "/testsuite/0/node/container1":
 			// GetSharedClientInfo
 			json.NewEncoder(w).Encode(simapi.NodeResponse{
 				ID:   "container1",
@@ -148,18 +148,18 @@ func TestSharedClientLogOffset(t *testing.T) {
 		case "/testsuite":
 			// StartSuite
 			json.NewEncoder(w).Encode(0) // Return suite ID
-		case "/testsuite/0/shared-client":
+		case "/testsuite/0/node":
 			// StartSharedClient
 			json.NewEncoder(w).Encode(simapi.StartNodeResponse{
 				ID: "container1",
 				IP: "192.0.2.1",
 			})
-		case "/testsuite/0/shared-client/container1/log-offset":
+		case "/testsuite/0/node/container1/log-offset":
 			// GetClientLogOffset - increment the offset each time it's called
 			currentOffset := offsetValue
 			offsetValue += 100 // Simulate log growth
 			json.NewEncoder(w).Encode(currentOffset)
-		case "/testsuite/0/shared-client/container1/exec":
+		case "/testsuite/0/node/container1/exec":
 			// ExecSharedClient
 			json.NewEncoder(w).Encode(&ExecInfo{
 				Stdout:   "test output",
@@ -254,13 +254,13 @@ func TestGetClientLogOffset(t *testing.T) {
 		case "/testsuite":
 			// StartSuite
 			json.NewEncoder(w).Encode(0) // Return suite ID
-		case "/testsuite/0/shared-client":
+		case "/testsuite/0/node":
 			// StartSharedClient
 			json.NewEncoder(w).Encode(simapi.StartNodeResponse{
 				ID: "container1",
 				IP: "192.0.2.1",
 			})
-		case "/testsuite/0/shared-client/container1/log-offset":
+		case "/testsuite/0/node/container1/log-offset":
 			// GetClientLogOffset
 			json.NewEncoder(w).Encode(int64(0)) // Initial log offset
 		default:

--- a/hivesim/shared_client_test.go
+++ b/hivesim/shared_client_test.go
@@ -74,8 +74,8 @@ func TestStartSharedClient(t *testing.T) {
 	}
 }
 
-// Tests AddSharedClient method in Suite.
-func TestAddSharedClient(t *testing.T) {
+// Tests suites that use shared clients.
+func TestSharedClientSuite(t *testing.T) {
 	var startedContainers int
 
 	tm, srv := newFakeAPI(&fakes.BackendHooks{
@@ -90,18 +90,53 @@ func TestAddSharedClient(t *testing.T) {
 	defer srv.Close()
 	defer tm.Terminate()
 
-	suite := Suite{
+	sim := NewAt(srv.URL)
+
+	suiteWithSharedClients := Suite{
 		Name:        "shared-client-suite",
 		Description: "Testing shared client registration",
 	}
-	suite.AddSharedClient("shared1", "client-1", Params(map[string]string{
-		"PARAM1": "value1",
-	}))
+	suiteWithSharedClients.SharedClientsOptions = func(clientDefinition *ClientDefinition) []StartOption {
+		return []StartOption{
+			Params(map[string]string{
+				"PARAM1": "value1",
+			}),
+		}
+	}
 
-	suite.Add(TestSpec{
+	sharedClientContainerID := ""
+	suiteWithSharedClients.Add(TestSpec{
 		Name: "test-using-shared-client",
 		Run: func(t *T) {
-			client := t.GetSharedClient("shared1")
+			sharedClientIDs := t.GetSharedClientIDs()
+			if len(sharedClientIDs) != 1 {
+				t.Fatal("wrong number of shared clients:", len(sharedClientIDs))
+			}
+			sharedClientContainerID = sharedClientIDs[0]
+			client := t.GetSharedClient(sharedClientContainerID)
+			if client == nil {
+				t.Fatal("shared client not found")
+			}
+
+			if client.Type != "client-1" {
+				t.Errorf("wrong client type: got %q, want %q", client.Type, "client-1")
+			}
+			if !client.IsShared {
+				t.Error("IsShared flag not set on client")
+			}
+		},
+	})
+	suiteWithSharedClients.Add(TestSpec{
+		Name: "another-test-using-shared-client",
+		Run: func(t *T) {
+			sharedClientIDs := t.GetSharedClientIDs()
+			if len(sharedClientIDs) != 1 {
+				t.Fatal("wrong number of shared clients:", len(sharedClientIDs))
+			}
+			if sharedClientIDs[0] != sharedClientContainerID {
+				t.Fatal("wrong shared client container ID:", sharedClientIDs[0], "!=", sharedClientContainerID)
+			}
+			client := t.GetSharedClient(sharedClientContainerID)
 			if client == nil {
 				t.Fatal("shared client not found")
 			}
@@ -115,8 +150,7 @@ func TestAddSharedClient(t *testing.T) {
 		},
 	})
 
-	sim := NewAt(srv.URL)
-	err := RunSuite(sim, suite)
+	err := RunSuite(sim, suiteWithSharedClients)
 	if err != nil {
 		t.Fatal("suite run failed:", err)
 	}
@@ -136,156 +170,5 @@ func TestAddSharedClient(t *testing.T) {
 	suiteResult := results[0]
 	if suiteResult.ClientInfo == nil || len(suiteResult.ClientInfo) == 0 {
 		t.Error("no shared clients in test results")
-	}
-}
-
-// Tests log offset tracking.
-func TestSharedClientLogOffset(t *testing.T) {
-	// Mock HTTP server for testing the log offset API
-	var offsetValue int64 = 0
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		switch r.URL.Path {
-		case "/testsuite":
-			// StartSuite
-			json.NewEncoder(w).Encode(0) // Return suite ID
-		case "/testsuite/0/node":
-			// StartSharedClient
-			json.NewEncoder(w).Encode(simapi.StartNodeResponse{
-				ID: "container1",
-				IP: "192.0.2.1",
-			})
-		case "/testsuite/0/node/container1/log-offset":
-			// GetClientLogOffset - increment the offset each time it's called
-			currentOffset := offsetValue
-			offsetValue += 100 // Simulate log growth
-			json.NewEncoder(w).Encode(currentOffset)
-		case "/testsuite/0/node/container1/exec":
-			// ExecSharedClient
-			json.NewEncoder(w).Encode(&ExecInfo{
-				Stdout:   "test output",
-				ExitCode: 0,
-			})
-		default:
-			http.NotFound(w, r)
-		}
-	}))
-	defer srv.Close()
-
-	sim := NewAt(srv.URL)
-	suiteID, err := sim.StartSuite(&simapi.TestRequest{Name: "log-offset-suite"}, "Testing log offset")
-	if err != nil {
-		t.Fatal("can't start suite:", err)
-	}
-
-	containerID, _, err := sim.StartSharedClient(suiteID, "client-1")
-	if err != nil {
-		t.Fatal("can't start shared client:", err)
-	}
-
-	// Get initial offset
-	initialOffset, err := sim.GetClientLogOffset(suiteID, containerID)
-	if err != nil {
-		t.Fatal("can't get initial log offset:", err)
-	}
-	if initialOffset != 0 {
-		t.Errorf("wrong initial offset: got %d, want 0", initialOffset)
-	}
-
-	// Simulate a command that generates logs
-	_, err = sim.ExecSharedClient(suiteID, containerID, []string{"/bin/echo", "test1"})
-	if err != nil {
-		t.Fatal("exec failed:", err)
-	}
-
-	// Get new offset - should have increased
-	newOffset, err := sim.GetClientLogOffset(suiteID, containerID)
-	if err != nil {
-		t.Fatal("can't get new log offset:", err)
-	}
-	if newOffset <= initialOffset {
-		t.Errorf("offset didn't increase: got %d, want > %d", newOffset, initialOffset)
-	}
-}
-
-// Tests log extraction functionality.
-func TestSharedClientLogExtraction(t *testing.T) {
-	// We can't fully test the log extraction in unit tests because it depends on file I/O.
-	// However, we can verify that the API endpoints are called correctly.
-	// The actual file operations are tested in integration tests.
-
-	// This test ensures that:
-	// 1. We use a MockSuite instead of real test cases
-	// 2. We verify that the ClientLogs structure is correctly set up
-
-	// Create a mock ClientLogs map for our test result
-	clientLogs := make(map[string]*libhive.ClientLogSegment)
-	clientLogs["shared1"] = &libhive.ClientLogSegment{
-		Start:    0,
-		End:      100,
-		ClientID: "container1",
-	}
-
-	// Create a mock test result
-	mockResult := &libhive.TestResult{
-		Pass:       true,
-		ClientLogs: clientLogs,
-	}
-
-	// Verify the test result has client logs
-	if mockResult.ClientLogs == nil {
-		t.Error("no client logs in test results")
-	}
-
-	if len(mockResult.ClientLogs) == 0 {
-		t.Error("empty client logs map")
-	}
-
-	// Verify the log segment values
-	logSegment := mockResult.ClientLogs["shared1"]
-	if logSegment.Start != 0 || logSegment.End != 100 || logSegment.ClientID != "container1" {
-		t.Errorf("unexpected log segment values: got %+v", logSegment)
-	}
-}
-
-// Tests GetClientLogOffset function.
-func TestGetClientLogOffset(t *testing.T) {
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		switch r.URL.Path {
-		case "/testsuite":
-			// StartSuite
-			json.NewEncoder(w).Encode(0) // Return suite ID
-		case "/testsuite/0/node":
-			// StartSharedClient
-			json.NewEncoder(w).Encode(simapi.StartNodeResponse{
-				ID: "container1",
-				IP: "192.0.2.1",
-			})
-		case "/testsuite/0/node/container1/log-offset":
-			// GetClientLogOffset
-			json.NewEncoder(w).Encode(int64(0)) // Initial log offset
-		default:
-			http.NotFound(w, r)
-		}
-	}))
-	defer srv.Close()
-
-	sim := NewAt(srv.URL)
-	suiteID, err := sim.StartSuite(&simapi.TestRequest{Name: "log-offset-test"}, "Test GetClientLogOffset")
-	if err != nil {
-		t.Fatal("can't start suite:", err)
-	}
-
-	containerID, _, err := sim.StartSharedClient(suiteID, "client-1")
-	if err != nil {
-		t.Fatal("can't start shared client:", err)
-	}
-
-	offset, err := sim.GetClientLogOffset(suiteID, containerID)
-	if err != nil {
-		t.Fatal("get log offset failed:", err)
-	}
-
-	if offset != 0 {
-		t.Errorf("wrong initial log offset: got %d, want 0", offset)
 	}
 }

--- a/hivesim/shared_client_test.go
+++ b/hivesim/shared_client_test.go
@@ -62,16 +62,6 @@ func TestStartSharedClient(t *testing.T) {
 	if !ip.Equal(expected) {
 		t.Errorf("wrong IP returned: got %v, want %v", ip, expected)
 	}
-
-	// Get client info
-	info, err := sim.GetSharedClientInfo(suiteID, containerID)
-	if err != nil {
-		t.Fatal("can't get shared client info:", err)
-	}
-
-	if info.ID != "container1" {
-		t.Errorf("wrong container ID in info: got %q, want %q", info.ID, "container1")
-	}
 }
 
 // Tests suites that use shared clients.

--- a/hivesim/testapi_test.go
+++ b/hivesim/testapi_test.go
@@ -81,18 +81,16 @@ func TestSuiteReporting(t *testing.T) {
 					Name:        "passing test",
 					Description: "this test passes",
 					SummaryResult: libhive.TestResult{
-						Pass:       true,
-						Details:    "message from the passing test\n",
-						ClientLogs: make(map[string]*libhive.ClientLogSegment),
+						Pass:    true,
+						Details: "message from the passing test\n",
 					},
 				},
 				2: {
 					Name:        "failing test",
 					Description: "this test fails",
 					SummaryResult: libhive.TestResult{
-						Pass:       false,
-						Details:    "message from the failing test\n",
-						ClientLogs: make(map[string]*libhive.ClientLogSegment),
+						Pass:    false,
+						Details: "message from the failing test\n",
 					},
 				},
 			},

--- a/hivesim/testapi_test.go
+++ b/hivesim/testapi_test.go
@@ -96,7 +96,7 @@ func TestSuiteReporting(t *testing.T) {
 					},
 				},
 			},
-			SharedClients: nil, // Add this field to expected results
+			ClientInfo: nil, // Add this field to expected results
 		},
 	}
 

--- a/hivesim/testapi_test.go
+++ b/hivesim/testapi_test.go
@@ -69,6 +69,37 @@ func TestSuiteReporting(t *testing.T) {
 			},
 		},
 	}
+	// Update expected results to match new fields
+	wantResults = map[libhive.TestSuiteID]*libhive.TestSuite{
+		0: {
+			ID:             0,
+			Name:           suite.Name,
+			Description:    suite.Description,
+			ClientVersions: make(map[string]string),
+			TestCases: map[libhive.TestID]*libhive.TestCase{
+				1: {
+					Name:        "passing test",
+					Description: "this test passes",
+					SummaryResult: libhive.TestResult{
+						Pass:       true,
+						Details:    "message from the passing test\n",
+						ClientLogs: make(map[string]*libhive.ClientLogSegment),
+					},
+				},
+				2: {
+					Name:        "failing test",
+					Description: "this test fails",
+					SummaryResult: libhive.TestResult{
+						Pass:       false,
+						Details:    "message from the failing test\n",
+						ClientLogs: make(map[string]*libhive.ClientLogSegment),
+					},
+				},
+			},
+			SharedClients: nil, // Add this field to expected results
+		},
+	}
+
 	if !reflect.DeepEqual(results, wantResults) {
 		t.Fatal("wrong results reported:", spew.Sdump(results))
 	}

--- a/internal/libhive/api.go
+++ b/internal/libhive/api.go
@@ -253,44 +253,6 @@ func (api *simAPI) startClient(w http.ResponseWriter, r *http.Request) {
 			// components should be ignored in the filename supplied by the form, and
 			// package multipart strips the directory info away at parse time.
 			files[key] = fheaders[0]
-
-			// Debug output for genesis.json allocations in regular clients
-			if key == "genesis.json" {
-				slog.Info("Regular client genesis.json detected", "filename", key)
-
-				// Read the file content
-				file, err := fheaders[0].Open()
-				if err == nil {
-					defer file.Close()
-
-					// Read the genesis file
-					genesisBytes, err := io.ReadAll(file)
-					if err == nil {
-						// Parse JSON to extract and log alloc information
-						var genesisMap map[string]interface{}
-						if err := json.Unmarshal(genesisBytes, &genesisMap); err == nil {
-							if alloc, ok := genesisMap["alloc"].(map[string]interface{}); ok {
-								// Log the number of accounts in alloc
-								slog.Info("Regular client genesis alloc accounts", "count", len(alloc))
-
-								// Log a few accounts as examples
-								i := 0
-								for addr, details := range alloc {
-									if i < 3 { // Log only first 3 accounts to avoid spam
-										slog.Info("Genesis alloc entry", "address", addr, "details", details)
-										i++
-									} else {
-										break
-									}
-								}
-							}
-						}
-
-						// Rewind the file for normal processing
-						file.Seek(0, 0)
-					}
-				}
-			}
 		}
 	}
 

--- a/internal/libhive/api.go
+++ b/internal/libhive/api.go
@@ -43,11 +43,11 @@ func newSimulationAPI(b ContainerBackend, env SimEnv, tm *TestManager, hive Hive
 	router.HandleFunc("/testsuite/{suite}/test/{test}", api.endTest).Methods("POST")
 
 	// Shared client routes
-	router.HandleFunc("/testsuite/{suite}/shared-client", api.startSharedClient).Methods("POST")
-	router.HandleFunc("/testsuite/{suite}/shared-client/{node}", api.getSharedClientInfo).Methods("GET")
-	router.HandleFunc("/testsuite/{suite}/shared-client/{node}/log-offset", api.getSharedClientLogOffset).Methods("GET")
-	router.HandleFunc("/testsuite/{suite}/shared-client/{node}/exec", api.execInSharedClient).Methods("POST")
-	router.HandleFunc("/testsuite/{suite}/shared-client/{node}", api.stopSharedClient).Methods("DELETE")
+	router.HandleFunc("/testsuite/{suite}/node", api.startSharedClient).Methods("POST")
+	router.HandleFunc("/testsuite/{suite}/node/{node}", api.getSharedClientInfo).Methods("GET")
+	router.HandleFunc("/testsuite/{suite}/node/{node}/log-offset", api.getSharedClientLogOffset).Methods("GET")
+	router.HandleFunc("/testsuite/{suite}/node/{node}/exec", api.execInSharedClient).Methods("POST")
+	router.HandleFunc("/testsuite/{suite}/node/{node}", api.stopSharedClient).Methods("DELETE")
 
 	// Regular client routes
 	router.HandleFunc("/testsuite/{suite}/test/{test}/node/{node}/exec", api.execInClient).Methods("POST")

--- a/internal/libhive/data.go
+++ b/internal/libhive/data.go
@@ -126,6 +126,9 @@ type TestSuite struct {
 	RunMetadata    *RunMetadata         `json:"runMetadata,omitempty"` // Enhanced run metadata
 	TestCases      map[TestID]*TestCase `json:"testCases"`
 
+	// Shared client support
+	SharedClients map[string]*ClientInfo `json:"sharedClients,omitempty"` // Map of shared clients available to all tests in this suite
+
 	SimulatorLog   string `json:"simLog"`         // path to simulator log-file simulator. (may be shared with multiple suites)
 	TestDetailsLog string `json:"testDetailsLog"` // the test details output file
 
@@ -152,6 +155,16 @@ type TestResult struct {
 	// suite's TestDetailsLog file ("log").
 	Details    string          `json:"details,omitempty"`
 	LogOffsets *TestLogOffsets `json:"log,omitempty"`
+
+	// ClientLogs stores log segments for shared clients used in this test
+	ClientLogs map[string]*ClientLogSegment `json:"clientLogs,omitempty"`
+}
+
+// ClientLogSegment represents a segment of a client log file
+type ClientLogSegment struct {
+	Start    int64  `json:"start"`    // Starting offset in log file
+	End      int64  `json:"end"`      // Ending offset in log file
+	ClientID string `json:"clientId"` // ID of the client
 }
 
 type TestLogOffsets struct {
@@ -166,6 +179,12 @@ type ClientInfo struct {
 	Name           string    `json:"name"`
 	InstantiatedAt time.Time `json:"instantiatedAt"`
 	LogFile        string    `json:"logFile"` //Absolute path to the logfile.
+
+	// Fields for shared client support
+	IsShared     bool  `json:"isShared"`     // Indicates if this client is shared across tests
+	LogPosition  int64 `json:"logPosition"`  // Current position in log file for shared clients
+	SuiteID      TestSuiteID `json:"suiteId,omitempty"` // Suite ID for shared clients
+	SharedClientID string    `json:"sharedClientId,omitempty"` // ID of the shared client (if this is a reference)
 
 	wait func()
 }

--- a/internal/libhive/data.go
+++ b/internal/libhive/data.go
@@ -78,7 +78,7 @@ func SanitizeContainerNameComponent(s string) string {
 
 // GenerateContainerName generates a Hive-prefixed container name
 func GenerateContainerName(containerType, identifier string) string {
-	timestamp := time.Now().Format("20060102-150405")
+	timestamp := time.Now().Format("20060102-150405.0000")
 	sanitizedType := SanitizeContainerNameComponent(containerType)
 	if identifier != "" {
 		sanitizedIdentifier := SanitizeContainerNameComponent(identifier)

--- a/internal/libhive/data.go
+++ b/internal/libhive/data.go
@@ -130,7 +130,7 @@ type TestSuite struct {
 	TestCases      map[TestID]*TestCase `json:"testCases"`
 
 	// Shared client support
-	SharedClients map[string]*ClientInfo `json:"sharedClients,omitempty"` // Map of shared clients available to all tests in this suite
+	ClientInfo map[string]*ClientInfo `json:"clientInfo,omitempty"` // Map of shared clients available to all tests in this suite
 
 	SimulatorLog   string `json:"simLog"`         // path to simulator log-file simulator. (may be shared with multiple suites)
 	TestDetailsLog string `json:"testDetailsLog"` // the test details output file

--- a/internal/libhive/data.go
+++ b/internal/libhive/data.go
@@ -162,9 +162,11 @@ type TestResult struct {
 
 // ClientLogSegment represents a segment of a client log file
 type ClientLogSegment struct {
-	Start    int64  `json:"start"`    // Starting offset in log file
-	End      int64  `json:"end"`      // Ending offset in log file
-	ClientID string `json:"clientId"` // ID of the client
+	Start     int64  `json:"start"`     // Starting byte offset in log file
+	End       int64  `json:"end"`       // Ending byte offset in log file
+	StartLine int    `json:"startLine"` // Starting line number
+	EndLine   int    `json:"endLine"`   // Ending line number
+	ClientID  string `json:"clientId"`  // ID of the client
 }
 
 type TestLogOffsets struct {
@@ -181,10 +183,10 @@ type ClientInfo struct {
 	LogFile        string    `json:"logFile"` //Absolute path to the logfile.
 
 	// Fields for shared client support
-	IsShared     bool  `json:"isShared"`     // Indicates if this client is shared across tests
-	LogPosition  int64 `json:"logPosition"`  // Current position in log file for shared clients
-	SuiteID      TestSuiteID `json:"suiteId,omitempty"` // Suite ID for shared clients
-	SharedClientID string    `json:"sharedClientId,omitempty"` // ID of the shared client (if this is a reference)
+	IsShared       bool        `json:"isShared"`                 // Indicates if this client is shared across tests
+	LogPosition    int64       `json:"logPosition"`              // Current position in log file for shared clients
+	SuiteID        TestSuiteID `json:"suiteId,omitempty"`        // Suite ID for shared clients
+	SharedClientID string      `json:"sharedClientId,omitempty"` // ID of the shared client (if this is a reference)
 
 	wait func()
 }

--- a/internal/libhive/data.go
+++ b/internal/libhive/data.go
@@ -9,15 +9,15 @@ import (
 
 // Docker label keys used by Hive
 const (
-	LabelHiveInstance    = "hive.instance"       // Unique Hive instance ID
-	LabelHiveVersion     = "hive.version"        // Hive version/commit
-	LabelHiveType        = "hive.type"           // container type: client|simulator|proxy
-	LabelHiveTestSuite   = "hive.test.suite"     // test suite ID
-	LabelHiveTestCase    = "hive.test.case"      // test case ID
-	LabelHiveClientName  = "hive.client.name"    // client name (go-ethereum, etc)
-	LabelHiveClientImage = "hive.client.image"   // Docker image name
-	LabelHiveCreated     = "hive.created"        // RFC3339 timestamp
-	LabelHiveSimulator   = "hive.simulator"      // simulator name
+	LabelHiveInstance    = "hive.instance"     // Unique Hive instance ID
+	LabelHiveVersion     = "hive.version"      // Hive version/commit
+	LabelHiveType        = "hive.type"         // container type: client|simulator|proxy
+	LabelHiveTestSuite   = "hive.test.suite"   // test suite ID
+	LabelHiveTestCase    = "hive.test.case"    // test case ID
+	LabelHiveClientName  = "hive.client.name"  // client name (go-ethereum, etc)
+	LabelHiveClientImage = "hive.client.image" // Docker image name
+	LabelHiveCreated     = "hive.created"      // RFC3339 timestamp
+	LabelHiveSimulator   = "hive.simulator"    // simulator name
 )
 
 // Container types
@@ -47,7 +47,7 @@ func SanitizeContainerNameComponent(s string) string {
 	if s == "" {
 		return s
 	}
-	
+
 	// Replace invalid characters with dashes
 	sanitized := ""
 	for i, r := range s {
@@ -61,10 +61,10 @@ func SanitizeContainerNameComponent(s string) string {
 			sanitized += "-"
 		}
 	}
-	
+
 	// Ensure first character is alphanumeric
-	if len(sanitized) > 0 && !((sanitized[0] >= 'a' && sanitized[0] <= 'z') || 
-		(sanitized[0] >= 'A' && sanitized[0] <= 'Z') || 
+	if len(sanitized) > 0 && !((sanitized[0] >= 'a' && sanitized[0] <= 'z') ||
+		(sanitized[0] >= 'A' && sanitized[0] <= 'Z') ||
 		(sanitized[0] >= '0' && sanitized[0] <= '9')) {
 		if len(sanitized) > 1 {
 			sanitized = sanitized[1:]
@@ -72,7 +72,7 @@ func SanitizeContainerNameComponent(s string) string {
 			sanitized = "container"
 		}
 	}
-	
+
 	return sanitized
 }
 
@@ -88,8 +88,11 @@ func GenerateContainerName(containerType, identifier string) string {
 }
 
 // GenerateClientContainerName generates a name for client containers
-func GenerateClientContainerName(clientName string, suiteID TestSuiteID, testID TestID) string {
-	identifier := fmt.Sprintf("%s-s%s-t%s", clientName, suiteID.String(), testID.String())
+func GenerateClientContainerName(clientName string, suiteID TestSuiteID, testID *TestID) string {
+	identifier := fmt.Sprintf("%s-s%s", clientName, suiteID.String())
+	if testID != nil {
+		identifier += fmt.Sprintf("-t%s", testID.String())
+	}
 	return GenerateContainerName("client", identifier)
 }
 

--- a/internal/libhive/data.go
+++ b/internal/libhive/data.go
@@ -158,9 +158,6 @@ type TestResult struct {
 	// suite's TestDetailsLog file ("log").
 	Details    string          `json:"details,omitempty"`
 	LogOffsets *TestLogOffsets `json:"log,omitempty"`
-
-	// ClientLogs stores log segments for shared clients used in this test
-	ClientLogs map[string]*ClientLogSegment `json:"clientLogs,omitempty"`
 }
 
 // ClientLogSegment represents a segment of a client log file
@@ -186,10 +183,9 @@ type ClientInfo struct {
 	LogFile        string    `json:"logFile"` //Absolute path to the logfile.
 
 	// Fields for shared client support
-	IsShared       bool        `json:"isShared"`                 // Indicates if this client is shared across tests
-	LogPosition    int64       `json:"logPosition"`              // Current position in log file for shared clients
-	SuiteID        TestSuiteID `json:"suiteId,omitempty"`        // Suite ID for shared clients
-	SharedClientID string      `json:"sharedClientId,omitempty"` // ID of the shared client (if this is a reference)
+	IsShared     bool   `json:"isShared"`               // Indicates if this client is shared across tests
+	LogStartLine *int64 `json:"logStartLine,omitempty"` // Start line in log file for shared clients
+	LogEndLine   *int64 `json:"logEndLine,omitempty"`   // End line in log file for shared clients
 
 	wait func()
 }

--- a/internal/libhive/data.go
+++ b/internal/libhive/data.go
@@ -184,8 +184,8 @@ type ClientInfo struct {
 
 	// Fields for shared client support
 	IsShared     bool   `json:"isShared"`               // Indicates if this client is shared across tests
-	LogStartLine *int64 `json:"logStartLine,omitempty"` // Start line in log file for shared clients
-	LogEndLine   *int64 `json:"logEndLine,omitempty"`   // End line in log file for shared clients
+	LogStartByte *int64 `json:"logStartByte,omitempty"` // Start byte in log file for shared clients
+	LogEndByte   *int64 `json:"logEndByte,omitempty"`   // End byte in log file for shared clients
 
 	wait func()
 }

--- a/internal/libhive/data_test.go
+++ b/internal/libhive/data_test.go
@@ -8,7 +8,7 @@ import (
 
 func TestGenerateHiveInstanceID(t *testing.T) {
 	id1 := GenerateHiveInstanceID()
-	
+
 	// Sleep briefly to ensure different timestamp
 	time.Sleep(time.Millisecond)
 	id2 := GenerateHiveInstanceID()
@@ -119,8 +119,9 @@ func TestGenerateContainerName(t *testing.T) {
 }
 
 func TestGenerateClientContainerName(t *testing.T) {
-	name := GenerateClientContainerName("go-ethereum", TestSuiteID(1), TestID(2))
-	
+	testID := TestID(2)
+	name := GenerateClientContainerName("go-ethereum", TestSuiteID(1), &testID)
+
 	if len(name) < 5 || name[:5] != "hive-" {
 		t.Errorf("Client container name should start with 'hive-', got: %s", name)
 	}
@@ -136,7 +137,7 @@ func TestGenerateClientContainerName(t *testing.T) {
 
 func TestGenerateSimulatorContainerName(t *testing.T) {
 	name := GenerateSimulatorContainerName("devp2p")
-	
+
 	if len(name) < 5 || name[:5] != "hive-" {
 		t.Errorf("Simulator container name should start with 'hive-', got: %s", name)
 	}
@@ -151,7 +152,7 @@ func TestGenerateSimulatorContainerName(t *testing.T) {
 
 func TestGenerateProxyContainerName(t *testing.T) {
 	name := GenerateProxyContainerName()
-	
+
 	if len(name) < 5 || name[:5] != "hive-" {
 		t.Errorf("Proxy container name should start with 'hive-', got: %s", name)
 	}
@@ -191,11 +192,11 @@ func TestSanitizeContainerNameComponent(t *testing.T) {
 func TestSanitizedContainerNames(t *testing.T) {
 	// Test that names with slashes get properly sanitized
 	name := GenerateSimulatorContainerName("ethereum/rpc-compat")
-	
+
 	if strings.Contains(name, "/") {
 		t.Errorf("Container name should not contain '/', got: %s", name)
 	}
-	
+
 	if !strings.Contains(name, "ethereum-rpc-compat") {
 		t.Errorf("Container name should contain sanitized simulator name, got: %s", name)
 	}

--- a/internal/simapi/simapi.go
+++ b/internal/simapi/simapi.go
@@ -11,11 +11,9 @@ type TestRequest struct {
 
 // NodeConfig contains the launch parameters for a client container.
 type NodeConfig struct {
-	Client         string            `json:"client"`
-	Networks       []string          `json:"networks"`
-	Environment    map[string]string `json:"environment"`
-	IsShared       bool              `json:"isShared,omitempty"`       // Whether this client is shared across tests
-	SharedClientID string            `json:"sharedClientId,omitempty"` // If set, this is a reference to an existing shared client
+	Client      string            `json:"client"`
+	Networks    []string          `json:"networks"`
+	Environment map[string]string `json:"environment"`
 }
 
 // StartNodeResponse is returned by the client startup endpoint.

--- a/internal/simapi/simapi.go
+++ b/internal/simapi/simapi.go
@@ -14,6 +14,7 @@ type NodeConfig struct {
 	Client      string            `json:"client"`
 	Networks    []string          `json:"networks"`
 	Environment map[string]string `json:"environment"`
+	IsShared    bool              `json:"isShared,omitempty"` // Whether this client is shared across tests
 }
 
 // StartNodeResponse is returned by the client startup endpoint.

--- a/internal/simapi/simapi.go
+++ b/internal/simapi/simapi.go
@@ -11,10 +11,11 @@ type TestRequest struct {
 
 // NodeConfig contains the launch parameters for a client container.
 type NodeConfig struct {
-	Client      string            `json:"client"`
-	Networks    []string          `json:"networks"`
-	Environment map[string]string `json:"environment"`
-	IsShared    bool              `json:"isShared,omitempty"` // Whether this client is shared across tests
+	Client         string            `json:"client"`
+	Networks       []string          `json:"networks"`
+	Environment    map[string]string `json:"environment"`
+	IsShared       bool              `json:"isShared,omitempty"`       // Whether this client is shared across tests
+	SharedClientID string            `json:"sharedClientId,omitempty"` // If set, this is a reference to an existing shared client
 }
 
 // StartNodeResponse is returned by the client startup endpoint.
@@ -27,6 +28,14 @@ type StartNodeResponse struct {
 type NodeResponse struct {
 	ID   string `json:"id"`
 	Name string `json:"name"`
+}
+
+// NodeInfo contains information about a client node to register with a test.
+type NodeInfo struct {
+	ID             string `json:"id"`                       // Container ID
+	Name           string `json:"name"`                     // Client name/type
+	IsShared       bool   `json:"isShared"`                 // Whether this is a shared client
+	SharedClientID string `json:"sharedClientId,omitempty"` // ID of the shared client in the suite
 }
 
 type ExecRequest struct {

--- a/simulators/ethereum/eest/consume-engine/Dockerfile
+++ b/simulators/ethereum/eest/consume-engine/Dockerfile
@@ -1,5 +1,5 @@
 # Builds and runs the EEST (execution-spec-tests) consume engine simulator
-FROM ghcr.io/astral-sh/uv:python3.10-bookworm-slim
+FROM ghcr.io/astral-sh/uv:python3.12-bookworm-slim
 
 ## Default fixtures/git-ref
 ARG fixtures=stable@latest

--- a/simulators/ethereum/eest/consume-enginex/Dockerfile
+++ b/simulators/ethereum/eest/consume-enginex/Dockerfile
@@ -1,0 +1,31 @@
+# Builds and runs the EEST (execution-spec-tests) consume engine simulator
+FROM ghcr.io/astral-sh/uv:python3.12-bookworm-slim
+
+## Default fixtures/git-ref
+ARG fixtures=stable@latest
+ENV FIXTURES=${fixtures}
+ARG branch=main
+ENV GIT_REF=${branch} 
+
+## Clone and install EEST
+RUN apt-get update && apt-get install -y git
+
+# Allow the user to specify a branch or commit to checkout
+RUN git init execution-spec-tests && \
+    cd execution-spec-tests && \
+    git remote add origin https://github.com/ethereum/execution-spec-tests.git && \
+    git fetch --depth 1 origin $GIT_REF && \
+    git checkout FETCH_HEAD;
+
+WORKDIR /execution-spec-tests
+RUN uv sync
+
+# Cache the fixtures. This is done to avoid re-downloading the fixtures every time
+# the container starts.
+# If newer version of the fixtures is needed, the image needs to be rebuilt.
+# Use `--docker.nocache` flag to force rebuild.
+RUN uv run consume cache --input "$FIXTURES"
+
+## Define `consume engine` entry point using the local fixtures
+ENTRYPOINT uv run consume enginex -v --input "$FIXTURES" --dist=loadgroup --enginex-fcu-frequency=0
+

--- a/simulators/ethereum/eest/consume-rlp/Dockerfile
+++ b/simulators/ethereum/eest/consume-rlp/Dockerfile
@@ -1,5 +1,5 @@
 # Builds and runs the EEST (execution-spec-tests) consume rlp simulator
-FROM ghcr.io/astral-sh/uv:python3.10-bookworm-slim
+FROM ghcr.io/astral-sh/uv:python3.12-bookworm-slim
 
 ## Default fixtures/git-ref
 ARG fixtures=stable@latest

--- a/simulators/ethereum/eest/execute-blobs/Dockerfile
+++ b/simulators/ethereum/eest/execute-blobs/Dockerfile
@@ -1,5 +1,5 @@
 # Builds and runs the EEST (execution-spec-tests) consume engine simulator
-FROM ghcr.io/astral-sh/uv:python3.10-bookworm-slim
+FROM ghcr.io/astral-sh/uv:python3.12-bookworm-slim
 
 ## Default git-ref/fork
 ARG branch=main

--- a/simulators/ethereum/engine/client/hive_rpc/hive_rpc.go
+++ b/simulators/ethereum/engine/client/hive_rpc/hive_rpc.go
@@ -6,6 +6,8 @@ import (
 	"math/big"
 	"net"
 	"net/http"
+	"os"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -91,10 +93,12 @@ func (s HiveRPCEngineStarter) StartClient(T *hivesim.T, testContext context.Cont
 	if err := CheckEthEngineLive(c); err != nil {
 		return nil, fmt.Errorf("Engine/Eth ports were never open for client: %v", err)
 	}
+	hiveLogLevel, _ := strconv.Atoi(os.Getenv("HIVE_LOGLEVEL"))
 	ec := NewHiveRPCEngineClient(c, enginePort, ethPort, jwtSecret, &helper.LoggingRoundTrip{
-		Logger: T,
-		ID:     c.Container,
-		Inner:  http.DefaultTransport,
+		Logger:   T,
+		ID:       c.Container,
+		Inner:    http.DefaultTransport,
+		LogLevel: hiveLogLevel,
 	})
 	return ec, nil
 }


### PR DESCRIPTION
This PR adds support for "shared clients", a new type of client that allows the client's instance (container) to be reused across multiple tests within a test suite. The aim is to preserve client state between tests in order to allow multiple EL tests to be executed against a single running client container to avoid client start-up time and speed-up testing.

#### Backend

- Added shared client API in `hivesim/hive.go` with methods: `StartSharedClient` and `GetSharedClientInfo`.
- Implemented suite-level client management in `hivesim/testapi.go` with `AddSharedClient` and `GetSharedClient`.
- Created necessary data structures in `hivesim/data.go` for tracking shared client state.
- Added log management for shared clients, allowing logs to be segmented on a per-test basis.
- Ensured proper cleanup of shared client containers when a test suite ends.
- Added line number calculation for log segments to use for client log UI display

#### Frontend

- Updated the test report UI to display links to shared client logs
- Added support for line-based log highlighting instead of byte offsets -> Entire log is displayed but link highlights and scrolls to the log segement of interest.

#### Testing

- Added dedicated unit tests in `shared_client_test.go` that cover all major functionality:
  - `TestStartSharedClient`: Tests client creation at the suite level
  - `TestAddSharedClient`: Tests client registration and retrieval in tests
  - `TestSharedClientLogOffset`: Tests log position tracking
  - `TestSharedClientLogExtraction`: Tests log segmentation
  - `TestGetClientLogOffset`: Tests the log offset API
